### PR TITLE
Fix stack corruption when logging long messages

### DIFF
--- a/lib/core/logger.cpp
+++ b/lib/core/logger.cpp
@@ -79,7 +79,7 @@ int popc_logger_t(LOGLEVEL level, const char* file, int line, const char* functi
     char msg[512];
     va_list ap;
     va_start(ap, format);
-    vsprintf(msg, format, ap);
+    vsnprintf(msg, (sizeof(msg) / sizeof(*msg)), format, ap);
     va_end(ap);
 
     auto msg_length = strlen(msg);

--- a/lib/core/logger.cpp
+++ b/lib/core/logger.cpp
@@ -79,7 +79,7 @@ int popc_logger_t(LOGLEVEL level, const char* file, int line, const char* functi
     char msg[512];
     va_list ap;
     va_start(ap, format);
-    vsnprintf(msg, (sizeof(msg) / sizeof(*msg)), format, ap);
+    vsnprintf(msg, sizeof(msg), format, ap);
     va_end(ap);
 
     auto msg_length = strlen(msg);


### PR DESCRIPTION
When logging a long message (longer than 512 bytes), the logger would corrupt the stack.
This patch does not raise the log message limit, but cuts off the message at 512 bytes through the usage of the save vsnprintf function.
