### PR TITLE
Protocol

### DIFF
--- a/include/core/pop_buffer.h
+++ b/include/core/pop_buffer.h
@@ -48,6 +48,8 @@
 #define TYPE_RESPONSE 1
 #define TYPE_EXCEPTION 2
 
+#define HEADER_SIZE 24
+
 class pop_interface;
 class pop_exception;
 class pop_combox;
@@ -68,14 +70,17 @@ public:
     inline int GetType() const {
         return type;
     }
-    inline int GetClassID() const {
+    inline int GetRequestID() const {
         return id[0];
     }
-    inline int GetMethodID() const {
+    inline int GetClassID() const {
         return id[1];
     }
-    inline int GetSemantics() const {
+    inline int GetMethodID() const {
         return id[2];
+    }
+    inline int GetSemantics() const {
+        return id[3];
     }
     inline int GetExceptionCode() const {
         return exception;
@@ -86,14 +91,17 @@ public:
     inline void SetType(int msgtype) {
         type = msgtype;
     }
+    inline void SetClassID(int requestid) {
+        id[0] = requestid;
+    }
     inline void SetClassID(int classid) {
-        id[0] = classid;
+        id[1] = classid;
     }
     inline void SetMethodID(int methodid) {
-        id[1] = methodid;
+        id[2] = methodid;
     }
     inline void SetSemantics(int semantics) {
-        id[2] = semantics;
+        id[3] = semantics;
     }
     inline void SetExceptionCode(int code) {
         exception = code;
@@ -104,7 +112,7 @@ public:
 
 private:
     int type;
-    int id[3];
+    int id[4];
     const char* methodname;
     int exception;
 };

--- a/include/core/pop_buffer.h
+++ b/include/core/pop_buffer.h
@@ -60,7 +60,7 @@ class pop_connection;
  */
 class pop_message_header {
 public:
-    pop_message_header(int classid, int methodid, int semantics, const char* methodname);
+    pop_message_header(int requestid, int classid, int methodid, int semantics, const char* methodname);
     pop_message_header(const char* methodname);
     pop_message_header(int exceptioncode, const char* methodname);
     pop_message_header();
@@ -91,7 +91,7 @@ public:
     inline void SetType(int msgtype) {
         type = msgtype;
     }
-    inline void SetClassID(int requestid) {
+    inline void SetRequestID(int requestid) {
         id[0] = requestid;
     }
     inline void SetClassID(int classid) {

--- a/interconnector/popc_mpi_interconnector.cpp
+++ b/interconnector/popc_mpi_interconnector.cpp
@@ -150,7 +150,7 @@ void* mpireceivedthread(void* t) {
 
                 if (rank != 0) {
                     // signal the IPC process to stop
-                    pop_message_header endheader(20, 200001, INVOKE_SYNC, "_terminate");
+                    pop_message_header endheader(-1, 20, 200001, INVOKE_SYNC, "_terminate");
                     ipcwaker_buffer->Reset();
                     ipcwaker_buffer->SetHeader(endheader);
                     ipcwaker_buffer->Send(ipcwaker, connection);
@@ -159,7 +159,7 @@ void* mpireceivedthread(void* t) {
             // Allocation of new parallel object
             case 11: {
                 // signal the IPC thread to be ready to receive data for allocation
-                pop_message_header endheader(20, 200004, INVOKE_SYNC, "_allocation");
+                pop_message_header endheader(-1, 20, 200004, INVOKE_SYNC, "_allocation");
                 ipcwaker_buffer->Reset();
                 ipcwaker_buffer->SetHeader(endheader);
                 ipcwaker_buffer->Send(ipcwaker, connection);
@@ -171,7 +171,7 @@ void* mpireceivedthread(void* t) {
             // Will receive a request from a redirection
             case 13: {
                 // printf("MPI request %d %d\n", rank, status.Get_source());
-                pop_message_header reqheader(status.Get_source(), 200005, INVOKE_SYNC, "_request");
+                pop_message_header reqheader(-1, status.Get_source(), 200005, INVOKE_SYNC, "_request");
                 ipcwaker_buffer->Reset();
                 ipcwaker_buffer->SetHeader(reqheader);
                 ipcwaker_buffer->Push("tag", "int", 1);

--- a/lib/core/broker.cc
+++ b/lib/core/broker.cc
@@ -386,7 +386,7 @@ bool pop_broker::WakeupReceiveThread(pop_combox* mycombox) {
 
         if (connected) {
             try {
-                pop_message_header h(0, 5, INVOKE_SYNC, "ObjectActive");
+                pop_message_header h(-1, 0, 5, INVOKE_SYNC, "ObjectActive");
                 buffer->Reset();
                 buffer->SetHeader(h);
                 pop_connection* connection = tmp->get_connection();

--- a/lib/core/buffer.cc
+++ b/lib/core/buffer.cc
@@ -29,11 +29,12 @@
 
 // Message header
 
-pop_message_header::pop_message_header(int classid, int methodid, int semantics, const char* metname) {
+pop_message_header::pop_message_header(int requestid, int classid, int methodid, int semantics, const char* metname) {
     type = TYPE_REQUEST;
-    id[0] = classid;
-    id[1] = methodid;
-    id[2] = semantics;
+    id[0] = requestid;
+    id[1] = classid;
+    id[2] = methodid;
+    id[3] = semantics;
     methodname = metname;
 }
 
@@ -61,9 +62,10 @@ void pop_message_header::operator=(const pop_message_header& dat) {
     SetMethodName(dat.GetMethodName());
     switch (type) {
         case TYPE_REQUEST:
-            id[0] = dat.GetClassID();
-            id[1] = dat.GetMethodID();
-            id[2] = dat.GetSemantics();
+            id[0] = dat.GetRequestID();
+            id[1] = dat.GetClassID();
+            id[2] = dat.GetMethodID();
+            id[3] = dat.GetSemantics();
             break;
         case TYPE_EXCEPTION:
             exception = dat.GetExceptionCode();

--- a/lib/dynamic/allocator_uds_interconnector.cpp
+++ b/lib/dynamic/allocator_uds_interconnector.cpp
@@ -71,7 +71,7 @@ std::string uds_allocator_interconnector::allocate(const std::string& objectname
         pop_exception::pop_throw(POP_NO_PROTOCOL, objectname, "Create or Connect failed");
     }
 
-    pop_message_header header(20, 200000, INVOKE_SYNC, "_allocate");
+    pop_message_header header(-1, 20, 200000, INVOKE_SYNC, "_allocate");
     allocating_buffer->Reset();
     allocating_buffer->SetHeader(header);
 
@@ -152,7 +152,7 @@ pop_combox* uds_allocator_interconnector::allocate_group(const std::string& obje
 
     delete local_interconnector_address;
 
-    pop_message_header header(0, 210000, INVOKE_SYNC, "_allocation");
+    pop_message_header header(-1, 0, 210000, INVOKE_SYNC, "_allocation");
     _popc_buffer->Reset();
     _popc_buffer->SetHeader(header);
 

--- a/lib/dynamic/broker_receive.cc
+++ b/lib/dynamic/broker_receive.cc
@@ -218,7 +218,7 @@ bool pop_broker::PopCall(pop_request& req) {
         case 0:
             // BindStatus call
             if (methodid[2] & INVOKE_SYNC) {
-                pop_message_header h(0, 0, INVOKE_SYNC, "BindStatus");
+                pop_message_header h(-1, 0, 0, INVOKE_SYNC, "BindStatus");
                 buf->Reset();
                 buf->SetHeader(h);
                 int status = 0;

--- a/lib/dynamic/buffer_xdr.cc
+++ b/lib/dynamic/buffer_xdr.cc
@@ -35,7 +35,7 @@ pop_buffer_xdr::~pop_buffer_xdr() {
 }
 
 void pop_buffer_xdr::Reset() {
-    unpackpos = 20;
+    unpackpos = HEADER_SIZE;
     packeddata.clear();
     packeddata.resize(unpackpos);
 }
@@ -502,26 +502,27 @@ bool pop_buffer_xdr::Send(pop_combox& s, pop_connection* conn) {
     }
 
     int n = packeddata.size();
-    int h[5];
-    memset(h, 0, 5 * sizeof(int));
+    int h[6];
+    memset(h, 0, 6 * sizeof(int));
 
     int type = header.GetType();
 
     h[0] = popc_htonl(n);
-    h[1] = popc_htonl(type);
+    h[1] = popc_htonl(header.GetRequestID());
+    h[2] = popc_htonl(type);
 
     switch (type) {
         case TYPE_REQUEST:
-            h[2] = popc_htonl(header.GetClassID());
-            h[3] = popc_htonl(header.GetMethodID());
-            h[4] = popc_htonl(header.GetSemantics());
+            h[3] = popc_htonl(header.GetClassID());
+            h[4] = popc_htonl(header.GetMethodID());
+            h[5] = popc_htonl(header.GetSemantics());
             break;
         case TYPE_EXCEPTION:
-            h[2] = popc_htonl(header.GetExceptionCode());
+            h[3] = popc_htonl(header.GetExceptionCode());
             break;
         case TYPE_RESPONSE:
-            h[2] = popc_htonl(header.GetClassID());
-            h[3] = popc_htonl(header.GetMethodID());
+            h[3] = popc_htonl(header.GetClassID());
+            h[4] = popc_htonl(header.GetMethodID());
             break;
         default:
             return false;
@@ -530,7 +531,7 @@ bool pop_buffer_xdr::Send(pop_combox& s, pop_connection* conn) {
     LOG_DEBUG_T("XDR", "Send methodid=%d", header.GetMethodID());
     LOG_DEBUG_T("XDR", "Send classId=%d", header.GetClassID());
 
-    memcpy(dat, h, 20);
+    memcpy(dat, h, HEADER_SIZE);
 
     return s.Send(dat, n, conn) >= 0;
 }
@@ -539,12 +540,12 @@ bool pop_buffer_xdr::Send(pop_combox& s, pop_connection* conn) {
  *
  */
 bool pop_buffer_xdr::Recv(pop_combox& s, pop_connection* conn) {
-    int h[5];
+    int h[6];
     int n, i;
 
     // Recv the header
     char* dat = (char*)h;
-    n = 20;
+    n = HEADER_SIZE;
     do {
         if ((i = s.Recv(dat, n, conn)) <= 0) {
             LOG_DEBUG("combox recv returned %d", i);
@@ -557,25 +558,27 @@ bool pop_buffer_xdr::Recv(pop_combox& s, pop_connection* conn) {
     Reset();
 
     n = popc_ntohl(h[0]);
-    if (n < 20) {
+    if (n < HEADER_SIZE) {
         LOG_ERROR("[CORE] XDR Buffer - Bad message header (size error:%d)", n);
         return false;
     }
 
-    int type = popc_ntohl(h[1]);
+    header.SetClassID(popc_ntohl(h[1]));
+    int type = popc_ntohl(h[2]);
     header.SetType(type);
+    
     switch (type) {
         case TYPE_REQUEST:
-            header.SetClassID(popc_ntohl(h[2]));
-            header.SetMethodID(popc_ntohl(h[3]));
-            header.SetSemantics(popc_ntohl(h[4]));
+            header.SetClassID(popc_ntohl(h[3]));
+            header.SetMethodID(popc_ntohl(h[4]));
+            header.SetSemantics(popc_ntohl(h[5]));
             break;
         case TYPE_EXCEPTION:
-            header.SetExceptionCode(popc_ntohl(h[2]));
+            header.SetExceptionCode(popc_ntohl(h[3]));
             break;
         case TYPE_RESPONSE:
-            header.SetClassID(popc_ntohl(h[2]));
-            header.SetMethodID(popc_ntohl(h[3]));
+            header.SetClassID(popc_ntohl(h[3]));
+            header.SetMethodID(popc_ntohl(h[4]));
             break;
         default:
             LOG_ERROR("Unknown type %d", type);
@@ -586,8 +589,8 @@ bool pop_buffer_xdr::Recv(pop_combox& s, pop_connection* conn) {
     LOG_DEBUG_T("XDR", "Read classId=%d", header.GetClassID());
 
     packeddata.resize(n);
-    n -= 20;
-    dat = packeddata.data() + 20;
+    n -= HEADER_SIZE;
+    dat = packeddata.data() + HEADER_SIZE;
 
     i = 0;
 
@@ -615,64 +618,66 @@ char* pop_buffer_xdr::get_load() {
     }
 
     int n = packeddata.size();
-    int h[5];
-    memset(h, 0, 5 * sizeof(int));
+    int h[6];
+    memset(h, 0, 6 * sizeof(int));
 
     int type = header.GetType();
 
     h[0] = popc_htonl(n);
-    h[1] = popc_htonl(type);
+    h[1] = popc_htonl(header.GetRequestID());
+    h[2] = popc_htonl(type);
 
     switch (type) {
         case TYPE_REQUEST:
-            h[2] = popc_htonl(header.GetClassID());
-            h[3] = popc_htonl(header.GetMethodID());
-            h[4] = popc_htonl(header.GetSemantics());
+            h[3] = popc_htonl(header.GetClassID());
+            h[4] = popc_htonl(header.GetMethodID());
+            h[5] = popc_htonl(header.GetSemantics());
             break;
         case TYPE_EXCEPTION:
-            h[2] = popc_htonl(header.GetExceptionCode());
+            h[3] = popc_htonl(header.GetExceptionCode());
             break;
         case TYPE_RESPONSE:
-            h[2] = popc_htonl(header.GetClassID());
-            h[3] = popc_htonl(header.GetMethodID());
+            h[3] = popc_htonl(header.GetClassID());
+            h[4] = popc_htonl(header.GetMethodID());
             break;
         default:
             LOG_ERROR("fail 2");
             return NULL;
     }
 
-    memcpy(dat, h, 20);
+    memcpy(dat, h, HEADER_SIZE);
 
     return packeddata.data();
 }
 
 void pop_buffer_xdr::load(char* data, int length) {
-    int h[5];
+    int h[6];
 
     Reset();
     memcpy(packeddata.data(), data, length);
-    memcpy(h, packeddata.data(), 20);
+    memcpy(h, packeddata.data(), HEADER_SIZE);
 
     int n = popc_ntohl(h[0]);
-    if (n < 20) {
+    if (n < HEADER_SIZE) {
         LOG_ERROR("[CORE] XDR Buffer - Bad message header (size error:%d)", n);
         return;
     }
-
-    int type = popc_ntohl(h[1]);
+    header.SetRequestID(popc_ntohl(h[1]));
+    
+    int type = popc_ntohl(h[2]);
     header.SetType(type);
     switch (type) {
         case TYPE_REQUEST:
-            header.SetClassID(popc_ntohl(h[2]));
-            header.SetMethodID(popc_ntohl(h[3]));
-            header.SetSemantics(popc_ntohl(h[4]));
+            header.SetClassID(popc_ntohl(h[3]));
+            header.SetMethodID(popc_ntohl(h[4]));
+            header.SetSemantics(popc_ntohl(h[5]));
             break;
         case TYPE_EXCEPTION:
-            header.SetExceptionCode(popc_ntohl(h[2]));
+            header.SetExceptionCode(popc_ntohl(h[3]));
             break;
         case TYPE_RESPONSE:
-            header.SetClassID(popc_ntohl(h[2]));
-            header.SetMethodID(popc_ntohl(h[3]));
+            header.SetClassID(popc_ntohl(h[3]));
+            header.SetMethodID(popc_ntohl(h[4]));
             break;
         default:
             return;

--- a/lib/dynamic/buffer_xdr_mpi.cpp
+++ b/lib/dynamic/buffer_xdr_mpi.cpp
@@ -527,7 +527,7 @@ void popc_buffer_xdr_mpi::load(char* data, int length) {
 
     header.SetRequestID(popc_ntohl(h[1]));
     
-    int type = popc_ntohl(h[2);
+    int type = popc_ntohl(h[2]);
     header.SetType(type);
     switch (type) {
         case TYPE_REQUEST:

--- a/lib/dynamic/interface.cc
+++ b/lib/dynamic/interface.cc
@@ -479,7 +479,7 @@ void pop_interface::Bind(const char* dest) {
         create_return = __pop_combox->Create(local_address, false);
         connect_return = __pop_combox->Connect(local_address);
 
-        pop_message_header header(20, 200002, INVOKE_SYNC, "_connection");
+        pop_message_header header(-1, 20, 200002, INVOKE_SYNC, "_connection");
         __pop_buf->Reset();
         __pop_buf->SetHeader(header);
 
@@ -579,7 +579,7 @@ void pop_interface::BindStatus(int& code, std::string& platform, std::string& in
         return;
     }
 
-    pop_message_header h(0, 0, INVOKE_SYNC, "BindStatus");
+    pop_message_header h(-1, 0, 0, INVOKE_SYNC, "BindStatus");
     pop_mutex_locker lock(_pop_imutex);
     __pop_buf->Reset();
     __pop_buf->SetHeader(h);
@@ -608,7 +608,7 @@ int pop_interface::AddRef() {
         return -1;
     }
 
-    pop_message_header h(0, 1, INVOKE_SYNC, "AddRef");
+    pop_message_header h(-1, 0, 1, INVOKE_SYNC, "AddRef");
     pop_mutex_locker lock(_pop_imutex);
     __pop_buf->Reset();
     __pop_buf->SetHeader(h);
@@ -630,7 +630,7 @@ int pop_interface::DecRef() {
         return -1;
     }
 
-    pop_message_header h(0, 2, INVOKE_SYNC, "DecRef");
+    pop_message_header h(-1, 0, 2, INVOKE_SYNC, "DecRef");
     pop_mutex_locker lock(_pop_imutex);
     __pop_buf->Reset();
     __pop_buf->SetHeader(h);
@@ -659,7 +659,7 @@ bool pop_interface::Encoding(std::string encoding) {
         return false;
     }
 
-    pop_message_header h(0, 3, INVOKE_SYNC, "Encoding");
+    pop_message_header h(-1, 0, 3, INVOKE_SYNC, "Encoding");
     pop_mutex_locker lock(_pop_imutex);
     __pop_buf->Reset();
     __pop_buf->SetHeader(h);
@@ -692,7 +692,7 @@ void pop_interface::Kill() {
         return;
     }
 
-    pop_message_header h(0, 4, 0, "Kill");
+    pop_message_header h(-1, 0, 4, 0, "Kill");
     pop_mutex_locker lock(_pop_imutex);
     __pop_buf->Reset();
     __pop_buf->SetHeader(h);
@@ -710,7 +710,7 @@ bool pop_interface::ObjectActive() {
         return false;
     }
 
-    pop_message_header h(0, 5, INVOKE_SYNC, "ObjectActive");
+    pop_message_header h(-1, 0, 5, INVOKE_SYNC, "ObjectActive");
     pop_mutex_locker lock(_pop_imutex);
     __pop_buf->Reset();
     __pop_buf->SetHeader(h);
@@ -738,7 +738,7 @@ bool pop_interface::RecvCtrl() {
     };
 
     char header_name[] = "ObjectAlive\0";
-    pop_message_header h(0, 6, INVOKE_SYNC, header_name);
+    pop_message_header h(-1, 0, 6, INVOKE_SYNC, header_name);
     pop_mutex_locker lock(_pop_imutex);
     while (true) {
         __pop_combox->SetTimeout(time_control);

--- a/lib/dynamic/objmain.std.cc
+++ b/lib/dynamic/objmain.std.cc
@@ -94,7 +94,7 @@ int main(int argc, char** argv) {
     // Send ack via callback
     if (callback_combox != NULL) {
         pop_buffer* buffer = callback_combox->GetBufferFactory()->CreateBuffer();
-        pop_message_header h(0, 200002, INVOKE_SYNC, "_callback");
+        pop_message_header h(-1, 0, 200002, INVOKE_SYNC, "_callback");
         buffer->SetHeader(h);
 
         buffer->Push("status", "int", 1);

--- a/lib/pseudodynamic/buffer_raw.cc
+++ b/lib/pseudodynamic/buffer_raw.cc
@@ -31,9 +31,9 @@ pop_buffer_raw::~pop_buffer_raw() {
 }
 
 void pop_buffer_raw::Reset() {
-    unpackpos = 20;
+    unpackpos = HEADER_SIZE;
     // packeddata.RemoveAll();
-    packeddata.resize(20);
+    packeddata.resize(unpackpos);
 }
 
 void pop_buffer_raw::Pack(const char* data, int n) {

--- a/lib/pseudodynamic/buffer_xdr.cc
+++ b/lib/pseudodynamic/buffer_xdr.cc
@@ -32,7 +32,7 @@ pop_buffer_xdr::~pop_buffer_xdr() {
 }
 
 void pop_buffer_xdr::Reset() {
-    unpackpos = 20;
+    unpackpos = HEADER_SIZE;
     packeddata.clear();
     packeddata.resize(unpackpos);
 }

--- a/lib/pseudodynamic/interface.cc
+++ b/lib/pseudodynamic/interface.cc
@@ -474,7 +474,7 @@ void pop_interface::BindStatus(int& code, std::string& platform, std::string& in
         return;
     }
 
-    pop_message_header h(0, 0, INVOKE_SYNC, "BindStatus");
+    pop_message_header h(-1, 0, 0, INVOKE_SYNC, "BindStatus");
     pop_mutex_locker lock(_pop_imutex);
     __pop_buf->Reset();
     __pop_buf->SetHeader(h);
@@ -503,7 +503,7 @@ int pop_interface::AddRef() {
         return -1;
     }
 
-    pop_message_header h(0, 1, INVOKE_SYNC, "AddRef");
+    pop_message_header h(-1, 0, 1, INVOKE_SYNC, "AddRef");
     pop_mutex_locker lock(_pop_imutex);
     __pop_buf->Reset();
     __pop_buf->SetHeader(h);
@@ -525,7 +525,7 @@ int pop_interface::DecRef() {
         return -1;
     }
 
-    pop_message_header h(0, 2, INVOKE_SYNC, "DecRef");
+    pop_message_header h(-1, 0, 2, INVOKE_SYNC, "DecRef");
     pop_mutex_locker lock(_pop_imutex);
     __pop_buf->Reset();
     __pop_buf->SetHeader(h);
@@ -554,7 +554,7 @@ bool pop_interface::Encoding(std::string encoding) {
         return false;
     }
 
-    pop_message_header h(0, 3, INVOKE_SYNC, "Encoding");
+    pop_message_header h(-1, 0, 3, INVOKE_SYNC, "Encoding");
     pop_mutex_locker lock(_pop_imutex);
     __pop_buf->Reset();
     __pop_buf->SetHeader(h);
@@ -588,7 +588,7 @@ void pop_interface::Kill() {
         return;
     }
 
-    pop_message_header h(0, 4, 0, "Kill");
+    pop_message_header h(-1, 0, 4, 0, "Kill");
     pop_mutex_locker lock(_pop_imutex);
     __pop_buf->Reset();
     __pop_buf->SetHeader(h);
@@ -606,7 +606,7 @@ bool pop_interface::ObjectActive() {
         return false;
     }
 
-    pop_message_header h(0, 5, INVOKE_SYNC, "ObjectActive");
+    pop_message_header h(-1, 0, 5, INVOKE_SYNC, "ObjectActive");
     pop_mutex_locker lock(_pop_imutex);
     __pop_buf->Reset();
     __pop_buf->SetHeader(h);
@@ -634,7 +634,7 @@ bool pop_interface::RecvCtrl() {
     };
 
     char header_name[] = "ObjectAlive\0";
-    pop_message_header h(0, 6, INVOKE_SYNC, header_name);
+    pop_message_header h(-1, 0, 6, INVOKE_SYNC, header_name);
     pop_mutex_locker lock(_pop_imutex);
     while (true) {
         __pop_combox->SetTimeout(time_control);

--- a/parser/classmember.cc
+++ b/parser/classmember.cc
@@ -899,7 +899,7 @@ void Method::GenerateClient(std::string& output) {
         output += tmpcode;
         snprintf(tmpcode, sizeof(tmpcode),
                  "\n  pop_connection* _popc_connection = __pop_combox->get_connection();\n  __pop_buf->Reset();\n  "
-                 "pop_message_header __pop_buf_header(CLASSUID_%s,%d,%d, \"%s\");\n  "
+                 "pop_message_header __pop_buf_header(-1, CLASSUID_%s,%d,%d, \"%s\");\n  "
                  "__pop_buf->SetHeader(__pop_buf_header);\n",
                  clname, id, invoke_code, name);
         output += tmpcode;
@@ -912,7 +912,7 @@ void Method::GenerateClient(std::string& output) {
             snprintf(
                 tmpcode, sizeof(tmpcode),
                 "\n  pop_connection* _popc_connection = _popc_combox->get_connection();\n  "
-                "_popc_buffer->Reset();\n  pop_message_header _popc_message_header(CLASSUID_%s, %d, %d, \"%s\");\n "
+                "_popc_buffer->Reset();\n  pop_message_header _popc_message_header(-1, CLASSUID_%s, %d, %d, \"%s\");\n "
                 " _popc_buffer->SetHeader(_popc_message_header);\n",
                 clname, POPC_METHOD_NON_COLLECTIVE_SIGNAL_ID, POPC_METHOD_NON_COLLECTIVE_SIGNAL_INVOKE_MODE,
                 POPC_METHOD_NON_COLLECTIVE_SIGNAL_NAME);
@@ -925,7 +925,7 @@ void Method::GenerateClient(std::string& output) {
 
             snprintf(tmpcode, sizeof(tmpcode),
                      "\n  popc_send_request(_popc_buffer, _popc_connection);\n  _popc_buffer->Reset();\n  "
-                     "pop_message_header _popc_message_header_call(CLASSUID_%s, %d, %d, \"%s\");",
+                     "pop_message_header _popc_message_header_call(-1, CLASSUID_%s, %d, %d, \"%s\");",
                      clname, id, invoke_code, name);
             output += tmpcode;
 
@@ -935,7 +935,7 @@ void Method::GenerateClient(std::string& output) {
             snprintf(
                 tmpcode, sizeof(tmpcode),
                 "\n  pop_connection* _popc_connection = _popc_combox->get_connection();\n  "
-                "_popc_buffer->Reset();\n  pop_message_header _popc_message_header(CLASSUID_%s, %d, %d, \"%s\");\n "
+                "_popc_buffer->Reset();\n  pop_message_header _popc_message_header(-1, CLASSUID_%s, %d, %d, \"%s\");\n "
                 " _popc_buffer->SetHeader(_popc_message_header);\n",
                 clname, id, invoke_code, name);
             output += tmpcode;


### PR DESCRIPTION
This branch adds a new information (requestID) to the header of POP-CPP requests/responses.
The usecase of this information is to differentiate the answers of multiple concurrent requests to the same remote object.

The current code only adds the requestID to the header. It does not yet set it correctly or use it. This is done to be compatible with POP-Java, which does use this information.

This merge request is not meant to be merged yet but serves as a work in progress and for discussion.
